### PR TITLE
Update warnings to point to current latest release, Amahi 8

### DIFF
--- a/fedora-14.md
+++ b/fedora-14.md
@@ -7,7 +7,7 @@ title: Install Fedora
 
 <div class="alert alert-error">
 <strong>WARNING: This Amahi release is unsupported at this time! Please use a supported release!
-The latest release is Amahi 7 Express.
+The latest release is [Amahi 8](amahi-8.html).
 </strong>
 </div>
 

--- a/ubuntu-12.md
+++ b/ubuntu-12.md
@@ -5,7 +5,7 @@ title: Install Amahi on Ubuntu 12.04.2 LTS
 # 1. Install Ubuntu
 <div class="alert alert-error">
 <strong>WARNING: This Amahi release is unsupported at this time! Please use a supported release!
-The latest release is Amahi 7 Express.
+The latest release is [Amahi 8](amahi-8.html).
 </strong>
 </div>
 


### PR DESCRIPTION
There is a message on the Ubuntu 12.04 and Fedora 14 pages reporting that the latest release is actually Amahi 7 Express. I have updated that to say Amahi 8 and to link to the Amahi 8 page.