### PR TITLE
Fixing weird <div> thing on my screen?

### DIFF
--- a/ubuntu-12.md
+++ b/ubuntu-12.md
@@ -24,9 +24,7 @@ The latest release is [Amahi 8](amahi-8.html).**
 
 ### Server install (headless)
 <span class="label label-important">WARNING</span>
-<div class="alert alert-error">
-SERVER INSTALL DOES NOT CURRENTLY WORK. <a href="http://bugs.amahi.org/issues/1015">USE THIS WORK-AROUND</a> IF YOU MUST.
-</div>
+**SERVER INSTALL DOES NOT CURRENTLY WORK. <a href="http://bugs.amahi.org/issues/1015">USE THIS WORK-AROUND</a> IF YOU MUST.**
 
 * Install Ubuntu Server until you reboot and are at the command line.
 * See this detailed guide for <a href="http://ubuntuserverguide.com/2012/05/how-to-install-ubuntu-server-12-04-lts-precise-pangolin-included-screenshot.html" target="_blank">installing Ubuntu Server</a>.

--- a/ubuntu-12.md
+++ b/ubuntu-12.md
@@ -24,7 +24,7 @@ The latest release is [Amahi 8](amahi-8.html).**
 
 ### Server install (headless)
 <span class="label label-important">WARNING</span>
-**SERVER INSTALL DOES NOT CURRENTLY WORK. <a href="http://bugs.amahi.org/issues/1015">USE THIS WORK-AROUND</a> IF YOU MUST.**
+**SERVER INSTALL DOES NOT CURRENTLY WORK. [USE THIS WORK-AROUND](http://bugs.amahi.org/issues/1015) IF YOU MUST.**
 
 * Install Ubuntu Server until you reboot and are at the command line.
 * See this detailed guide for <a href="http://ubuntuserverguide.com/2012/05/how-to-install-ubuntu-server-12-04-lts-precise-pangolin-included-screenshot.html" target="_blank">installing Ubuntu Server</a>.


### PR DESCRIPTION
I noticed a bit on the Ubuntu 12.04 page looking like this:

![screenshot from 2015-10-24 11 10 07](https://cloud.githubusercontent.com/assets/5488971/10711134/4af09344-7a40-11e5-9264-5ae6400060af.png)

So I have updated it in the same style that you changed the warnings at the top of each page, @cpg 

Maybe this was caused by a stylesheet change? Should look just like the other warnings now though.